### PR TITLE
implement __iter & len metamethods

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -14,16 +14,13 @@ function meta.__index(t, k)
 	return t.Value[k]
 end
 
-
 function meta.__len(t)
 	return #t.Value
 end
 
-
 function meta.__iter(t)
 	return next, t.Value
 end
-
 
 --[=[
 	@class TableValue

--- a/src/init.lua
+++ b/src/init.lua
@@ -14,6 +14,17 @@ function meta.__index(t, k)
 	return t.Value[k]
 end
 
+
+function meta.__len(t)
+	return #t.Value
+end
+
+
+function meta.__iter(t)
+	return next, t.value
+end
+
+
 --[=[
 	@class TableValue
 ]=]

--- a/src/init.lua
+++ b/src/init.lua
@@ -21,7 +21,7 @@ end
 
 
 function meta.__iter(t)
-	return next, t.value
+	return next, t.Value
 end
 
 


### PR DESCRIPTION
TableValues can now be directly iterated **with the generic iterator**

```lua
local t = {a, b, c, d, e}

print(#t) -- 5
for i, v in t do
    print(i, v) -- a b c d e
end

```
ipairs and pairs **only work with `.value`** 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving the length of proxy tables.
  * Enabled iteration over proxy tables using generic for loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->